### PR TITLE
feat(qa): rule-based consistency checker for MVP-β #14

### DIFF
--- a/backend/app/api/qa.py
+++ b/backend/app/api/qa.py
@@ -1,11 +1,12 @@
 """Quality Assurance API endpoints."""
 
-from fastapi import APIRouter, Depends
-from pydantic import BaseModel
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.schemas import ConsistencyResult
 from app.core.database import get_db
+from app.models.tables import Project
 from app.services.consistency import run_consistency_check
 
 router = APIRouter(prefix="/api", tags=["qa"])
@@ -13,8 +14,8 @@ router = APIRouter(prefix="/api", tags=["qa"])
 
 class ConsistencyCheckRequest(BaseModel):
     project_id: int
-    ngram_n: int = 4
-    ngram_threshold: int = 3
+    ngram_n: int = Field(default=4, ge=2, le=10)
+    ngram_threshold: int = Field(default=3, ge=2, le=20)
 
 
 @router.post("/qa/check", response_model=list[ConsistencyResult])
@@ -23,6 +24,9 @@ async def check_consistency(
     db: AsyncSession = Depends(get_db),
 ):
     """Run rule-based consistency checks on a project."""
+    project = await db.get(Project, body.project_id)
+    if not project:
+        raise HTTPException(404, "Project not found")
     return await run_consistency_check(
         db,
         body.project_id,


### PR DESCRIPTION
## Summary
- Implements 5 consistency checks: character_status, timeline, possession, plot_thread, repetition
- API: POST /api/qa/check with project_id, ngram_n, ngram_threshold
- Service: run_consistency_check() with scene indexing and KG analysis
- Tests: 12 tests covering all check types and API endpoint

## Changes
- `backend/app/api/qa.py`: QA API endpoint
- `backend/app/services/consistency.py`: Rule-based consistency checker (427 lines)
- `backend/tests/test_consistency.py`: 12 comprehensive tests (318 lines)
- `backend/app/api/schemas.py`: ConsistencyResult schema
- `backend/app/main.py`: Register QA router
- `frontend/src/lib/types.ts`: TypeScript types for consistency results

## Test Plan
- [x] All 12 backend tests passing
- [ ] Frontend UI integration (pending)
- [ ] Manual testing with sample project

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)