### PR TITLE
feat(frontend): homepage project create/delete with style presets (#42, #43)

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { apiFetch } from '@/lib/api'
 import { useWorkspace } from '@/hooks/use-workspace'
@@ -57,6 +57,9 @@ export default function WorkspacePage() {
       apiFetch(`/api/projects/${id}`, { method: 'DELETE' }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['projects'] })
+    },
+    onError: () => {
+      alert('删除失败，请重试')
     },
   })
 
@@ -334,6 +337,14 @@ function CreateProjectModal({
   const [tense, setTense] = useState('')
   const [creating, setCreating] = useState(false)
   const [error, setError] = useState('')
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !creating) onClose()
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [onClose, creating])
 
   const handleCreate = async () => {
     if (!title.trim()) {


### PR DESCRIPTION
## Summary

- 首页新增「+ 新建小说」按钮，打开创建弹窗
- 创建弹窗支持预设类型(Genre)、风格(Style)、视角(POV)、时态(Tense)
- 预设值创建后自动写入 Story Bible 对应字段
- 每个项目卡片新增删除按钮（带二次确认）
- Closes #42, Closes #43

## Test plan

- [ ] 首页显示「+ 新建小说」按钮
- [ ] 点击打开创建弹窗，包含标题/简介/类型/风格/视角/时态字段
- [ ] 创建成功后自动进入项目
- [ ] Bible 字段已被预设值填充
- [ ] 删除按钮显示在项目卡片右侧
- [ ] 删除前弹出确认对话框
- [ ] 确认后项目被删除，列表刷新
- [ ] `pnpm build` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)